### PR TITLE
main() should never, ever be typed as void -- always as int.

### DIFF
--- a/LOGINSYSTEM.C
+++ b/LOGINSYSTEM.C
@@ -3,7 +3,7 @@
 
 #include<stdio.h>
 #include<conio.h>
-void main()
+int main()
 {
   char str1[50],str2[50];
   int i=0;


### PR DESCRIPTION
If you have seen `void main()` somewhere, it is wrong. The type of `main()` should ALWAYS be `int`.